### PR TITLE
Add feature to check for deployment errors

### DIFF
--- a/bin/check_passenger
+++ b/bin/check_passenger
@@ -46,6 +46,15 @@ class CheckPassengerCLI < Thor
     end
   end
 
+  desc 'deployment_error', 'Check Passenger deployment errors'
+  option :warn, :default => '0'
+  option :crit, :default => '0'
+  def deployment_error
+    run_check do
+      CheckPassenger::Check.deployment_error(options)
+    end
+  end
+
   private
 
   def dump_passenger_status_output(exception = nil)

--- a/lib/check_passenger/check.rb
+++ b/lib/check_passenger/check.rb
@@ -10,7 +10,8 @@ module CheckPassenger
       COUNTER_LABELS = {
         live_process_count: '%d live processes',
         memory: '%dMB memory used',
-        process_count: '%d processes'
+        process_count: '%d processes',
+        deployment_error: '%d deployment errors',
       }
 
       def check_counter(counter_name, options = {})

--- a/lib/check_passenger/parser.rb
+++ b/lib/check_passenger/parser.rb
@@ -40,6 +40,15 @@ module CheckPassenger
       end
     end
 
+    def deployment_error(app_name = nil)
+      if app_name
+        app_data = application_data(app_name)
+        app_data[:deployment_error]
+      else
+        @application_data.inject(0) { |sum, e| sum + e[:deployment_error] }
+      end
+    end
+
     private
 
     def application_data(app_name)
@@ -90,7 +99,7 @@ module CheckPassenger
         app_data[:live_process_count] = (
           app_output.scan(/Last used *: *([^\n]+)/).select { |m| is_process_alive?(m[0]) }
         ).size
-
+        app_data[:deployment_error] = ( app_output.scan(/Resisting deployment error\!/).empty? ? 0 : 1 )
         app_data
       end
     end

--- a/lib/check_passenger/version.rb
+++ b/lib/check_passenger/version.rb
@@ -1,3 +1,3 @@
 module CheckPassenger
-  VERSION = "0.2"
+  VERSION = "0.3"
 end


### PR DESCRIPTION
This still needs tests. However, here's a look at the code to ensure this is a good path forward.  Keep in mind that deployment errors are related only to the passenger-enterprise version.  When using passenger-enterprise, you can use the `PassengerRollingRestarts on` option to prevent bad code from taking down your application instance.  Rolling restarts are an awesome feature, but you need to know when this feature kicks in, so you can address immediately.  Thus, the desire for adding this check.

Keep in mind this won't break the gem when using with the plain passenger version.  The deployment_error check just won't trigger with the open source version.