### PR TITLE
New Feature: Add a check for requests in the global queue and applica…

### DIFF
--- a/bin/check_passenger
+++ b/bin/check_passenger
@@ -46,6 +46,15 @@ class CheckPassengerCLI < Thor
     end
   end
 
+  desc 'requests', 'Check queued Passenger requests'
+  option :warn, aliases: 'w', banner: 'Request count threshold to raise warning status'
+  option :crit, aliases: 'c', banner: 'Request count threshold to raise critical status'
+  def requests
+    run_check do
+      CheckPassenger::Check.request_count(options)
+    end
+  end
+
   private
 
   def dump_passenger_status_output(exception = nil)

--- a/lib/check_passenger/check.rb
+++ b/lib/check_passenger/check.rb
@@ -10,7 +10,8 @@ module CheckPassenger
       COUNTER_LABELS = {
         live_process_count: ['%d live process', '%d live processes'],
         memory: '%dMB memory used',
-        process_count: ['%d process', '%d processes']
+        process_count: ['%d process', '%d processes'],
+        request_count: ['%d request', '%d requests']
       }
 
       def check_counter(counter_name, options = {})

--- a/lib/check_passenger/parser.rb
+++ b/lib/check_passenger/parser.rb
@@ -40,6 +40,15 @@ module CheckPassenger
       end
     end
 
+    def request_count(app_name = nil)
+      if app_name
+        app_data = application_data(app_name)
+        app_data[:request_count]
+      else
+        @request_count
+      end
+    end
+
     private
 
     def application_data(app_name)
@@ -85,6 +94,10 @@ module CheckPassenger
         raise StatusOutputError.new('Could not find app name', passenger_status_output) unless $1
         app_data[:name] = $1.strip
 
+        app_output =~ /Requests in queue: *(\d+)/
+        raise StatusOutputError.new('Could not find requests queued', passenger_status_output) unless $1
+        app_data[:request_count] = $1.strip.to_i
+
         app_data[:process_count] = app_output.scan(/PID *: *\d+/).size
         app_data[:memory] = app_output.scan(/Memory *: *(\d+)M/).inject(0.0) { |s, m| s + m[0].to_f }
         app_data[:live_process_count] = (
@@ -113,6 +126,10 @@ module CheckPassenger
       generic_data =~ /Processes *: *(\d+)/
       raise StatusOutputError.new('Could not find process count', passenger_status_output) unless $1
       @process_count = $1.to_i
+
+      generic_data =~ /Requests in top-level queue *: *(\d+)/
+      raise StatusOutputError.new('Could not find request queue', passenger_status_output) unless $1
+      @request_count = $1.to_i
 
       @application_data = parse_application_data(application_data)
     end

--- a/lib/check_passenger/version.rb
+++ b/lib/check_passenger/version.rb
@@ -1,3 +1,3 @@
 module CheckPassenger
-  VERSION = '1.0'
+  VERSION = '1.1'
 end

--- a/test/passenger-status
+++ b/test/passenger-status
@@ -9,7 +9,7 @@ Instance: 32028
 ----------- General information -----------
 Max pool size : 40
 Processes     : 26
-Requests in top-level queue : 0
+Requests in top-level queue : 10
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
@@ -42,7 +42,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 2
   * PID: 26712   Sessions: 0       Processed: 184     Uptime: 21h 36m 36s
     CPU: 0%      Memory  : 26M     Last used: 1m 11s
   * PID: 26721   Sessions: 0       Processed: 0       Uptime: 21h 36m 35s
@@ -54,7 +54,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 3
   * PID: 17507   Sessions: 0       Processed: 2141    Uptime: 21h 43m 33s
     CPU: 0%      Memory  : 242M    Last used: 5h 51m
   * PID: 17514   Sessions: 0       Processed: 5967    Uptime: 21h 43m 33s
@@ -70,7 +70,7 @@ Requests in top-level queue : 0
 
 /home/application_4/Site#default:
   App root: /home/application_4/Site
-  Requests in queue: 0
+  Requests in queue: 4
   * PID: 32383   Sessions: 0       Processed: 2182    Uptime: 2h 7m 9s
     CPU: 0%      Memory  : 76M     Last used: 2s ago
   * PID: 23605   Sessions: 0       Processed: 609     Uptime: 1h 7m 25s

--- a/test/sample_output_1.txt
+++ b/test/sample_output_1.txt
@@ -3,13 +3,13 @@ Date    : 2014-09-11 00:57:57 +0200
 Instance: 32028
 ----------- General information -----------
 Max pool size : 40
-Processes     : 26
-Requests in top-level queue : 0
+Processes     : 1
+Requests in top-level queue : 10
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 11
   * PID: 12396   Sessions: 0       Processed: 13322   Uptime: 19h 12m 52s
     CPU: 0%      Memory  : 153M    Last used: 51m 29s
   * PID: 12404   Sessions: 0       Processed: 11694   Uptime: 19h 12m 52s
@@ -37,7 +37,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 12
   * PID: 26712   Sessions: 0       Processed: 184     Uptime: 21h 36m 36s
     CPU: 0%      Memory  : 26M     Last used: 1m 11s
   * PID: 26721   Sessions: 0       Processed: 0       Uptime: 21h 36m 35s
@@ -49,7 +49,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 13
   * PID: 17507   Sessions: 0       Processed: 2141    Uptime: 21h 43m 33s
     CPU: 0%      Memory  : 242M    Last used: 5h 51m
   * PID: 17514   Sessions: 0       Processed: 5967    Uptime: 21h 43m 33s
@@ -65,7 +65,7 @@ Requests in top-level queue : 0
 
 /home/application_4/Site#default:
   App root: /home/application_4/Site
-  Requests in queue: 0
+  Requests in queue: 14
   * PID: 32383   Sessions: 0       Processed: 2182    Uptime: 2h 7m 9s
     CPU: 0%      Memory  : 76M     Last used: 2s ago
   * PID: 23605   Sessions: 0       Processed: 609     Uptime: 1h 7m 25s

--- a/test/sample_output_2.txt
+++ b/test/sample_output_2.txt
@@ -3,13 +3,13 @@ Date    : 2014-09-10 21:24:22 -0400
 Instance: 28669
 ----------- General information -----------
 Max pool size : 40
-Processes     : 22
-Requests in top-level queue : 0
+Processes     : 20
+Requests in top-level queue : 12
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 21
   * PID: 10966   Sessions: 0       Processed: 10840   Uptime: 15h 39m 16s
     CPU: 1%      Memory  : 170M    Last used: 17s ago
   * PID: 10974   Sessions: 0       Processed: 0       Uptime: 15h 39m 16s
@@ -37,7 +37,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 22
   * PID: 1679    Sessions: 0       Processed: 1273    Uptime: 3d 17h 40m 10s
     CPU: 0%      Memory  : 45M     Last used: 6m 4
   * PID: 1686    Sessions: 0       Processed: 0       Uptime: 3d 17h 40m 10s
@@ -49,7 +49,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 23
   * PID: 8170    Sessions: 0       Processed: 13179   Uptime: 1d 12h 8m 46s
     CPU: 1%      Memory  : 612M    Last used: 0s ag
   * PID: 8180    Sessions: 0       Processed: 20043   Uptime: 1d 12h 8m 45s

--- a/test/sample_output_3.txt
+++ b/test/sample_output_3.txt
@@ -3,25 +3,25 @@ Date    : 2015-05-30 01:53:14 +0200
 Instance: 1965
 ----------- General information -----------
 Max pool size : 50
-Processes     : 6
-Requests in top-level queue : 0
+Processes     : 30
+Requests in top-level queue : 13
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 1
   * PID: 14518   Sessions: 0       Processed: 11723   Uptime: 20h 8m 7s
     CPU: 0%      Memory  : 144M    Last used: 1m 33s ag
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 32
   * PID: 14134   Sessions: 0       Processed: 2313    Uptime: 20h 8m 10s
     CPU: 0%      Memory  : 63M     Last used: 6h 22m 4
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 33
   * PID: 21058   Sessions: 0       Processed: 725     Uptime: 2d 22h 35m 38s
     CPU: 0%      Memory  : 30M     Last used: 5m 4
   * PID: 21071   Sessions: 0       Processed: 0       Uptime: 2d 22h 35m 38s

--- a/test/test_check.rb
+++ b/test/test_check.rb
@@ -36,7 +36,7 @@ describe CheckPassenger::Check do
         output_data_structure_test(output_data)
 
         assert_equal 'process_count', output_data.first[:counter]
-        assert_equal 26, output_data.first[:value]
+        assert_equal 1, output_data.first[:value]
       end
 
       it 'reports global memory' do
@@ -73,6 +73,17 @@ describe CheckPassenger::Check do
         assert_equal 9, output_data.first[:value]
       end
 
+      it 'reports global request queue' do
+        options = { parsed_data: @parsed_data }
+        output_status, output_data = CheckPassenger::Check.request_count(options)
+
+        assert :ok, output_status
+        output_data_structure_test(output_data)
+
+        assert_equal 'request_count', output_data.first[:counter]
+        assert_equal 10, output_data.first[:value]
+      end
+
       it 'reports application process count' do
         options = { parsed_data: @parsed_data, app_name: 'application_1' }
         output_status, output_data = CheckPassenger::Check.process_count(options)
@@ -106,6 +117,17 @@ describe CheckPassenger::Check do
         assert_equal 1, output_data.first[:value]
       end
 
+      it 'reports application request queue count' do
+        options = { parsed_data: @parsed_data, app_name: 'application_4' }
+        output_status, output_data = CheckPassenger::Check.request_count(options)
+
+        assert_equal :ok, output_status
+        output_data_structure_test(output_data)
+
+        assert_equal 'request_count', output_data.first[:counter]
+        assert_equal 14, output_data.first[:value]
+      end
+
       it 'sets a warn alert when value over threshold' do
         options = { parsed_data: @parsed_data, app_name: 'application_4', warn: '150', crit: '300' }
         output_status, output_data = CheckPassenger::Check.memory(options)
@@ -133,24 +155,32 @@ describe CheckPassenger::Check do
       assert output_data.first[:text] =~ /\b6 processes\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b1 live process\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b30 requests\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_1' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b1 process\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b1 live process\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b1 request\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_2' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b1 process\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b0 live processes\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b32 requests\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_3' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b4 processes\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b0 live processes\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b33 requests\b/, output_data.first[:text]
     end
 
     it 'raises an alert if the application is not running' do

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -9,7 +9,7 @@ describe CheckPassenger::Parser do
         Instance: 32028
         ----------- General information -----------
         Max pool size : 40
-        Processes     : 26
+        Processes     : 55
         Requests in top-level queue : 0
 
         ----------- Application groups -----------
@@ -86,11 +86,15 @@ describe CheckPassenger::Parser do
       end
 
       it 'reports the total count of processes' do
-        assert_equal 26, @parser.process_count
+        assert_equal 1, @parser.process_count
       end
 
       it 'reports the number of live processes' do
         assert_equal 9, @parser.live_process_count
+      end
+
+      it 'reports the number of requests queueed' do
+        assert_equal 10, @parser.request_count
       end
     end
 
@@ -106,6 +110,10 @@ describe CheckPassenger::Parser do
       it 'reports the live process count' do
         assert_equal 3, @parser.live_process_count('application_1')
         assert_equal 4, @parser.live_process_count('application_4')
+      end
+
+      it 'reports the requests queued' do
+        assert_equal 12, @parser.request_count('application_2')
       end
 
       it 'raises exception if term matches multiple apps' do
@@ -140,7 +148,7 @@ describe CheckPassenger::Parser do
       end
 
       it 'reports the total count of processes' do
-        assert_equal 22, @parser.process_count
+        assert_equal 20, @parser.process_count
     end
 
       it 'reports the number of live processes' do


### PR DESCRIPTION
I added a check for requests in the request queue. Busy site often tune their request queues to be quite large. Growing request queue should be a clue that there aren't enough workers for an application. 

The only test I couldn't get to pass was the plural/not plural test. Not sure what I'm doing wrong there. 
I also modified the sample data for my tests.
Added a note that the gem only works with Ruby 1.9+. Won't work on 1.8 in my testing.

Let me know if you have any questions. And thanks for writing such an easy gem to modify. Made adding this feature really nice.