### PR TITLE
add request queue checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Alternatively, the gem can be built from the source code with `gem build`, and m
 
 Either way, the `check_passenger` command should become available in the path—although it may be necessary to perform an additional action, such as running `rbenv rehash` or similar.
 
+This gem requires Ruby 1.9+.
+
 
 ## Usage
 
@@ -31,6 +33,7 @@ Where the `<mode>` argument can be on of the following:
 * `processes`: These are the Passenger processes that are currently running, associated to applications.
 * `live_processes`: Of all the running processes, how many are actually being used. See the section [Passenger Live Processes](#passenger-live-processes) below.
 * `memory`: Memory occupied by the Passenger processes that are running.
+* `request_count`: These are the Passenger requests that are currently in ALL queues. See the section [Passenger Request Queues](#passenger-request-queues) below.
 
 In addition, **check\_passenger** can be called with the following options:
 
@@ -48,7 +51,7 @@ Finally, run `check_passenger help [mode]` to get usage information on the comma
 
 ## Global or Per-Application Reporting
 
-For each of the aspects that **check\_passenger** can monitor (processes, live processes, and memory), it can focus on all the applications running with Passenger, or on a specific application. This is controlled with the `-n` (`--app-name`), and `-a` (`--include-all`) options, as seen in the following examples.
+For each of the aspects that **check\_passenger** can monitor (processes, live processes, request queue, and memory), it can focus on all the applications running with Passenger, or on a specific application. This is controlled with the `-n` (`--app-name`), and `-a` (`--include-all`) options, as seen in the following examples.
 
 The following command returns a counter for all the running Passenger processes in the machine:
 
@@ -75,7 +78,7 @@ Finally, it's possible to obtain a global counter, together with additional coun
 
 This allows to monitor a resource, together with how much of it is being used by each application. Note though, that when monitoring a particular counter for all the applications in this way, it won't be possible to set alerts—just add an additional check for the alert you want to set for an application or globally.
 
-All these examples work the same with processes, live processes, and memory.
+All these examples work the same with processes, live processes, request queue, and memory.
 
 
 ## Passenger Live Processes
@@ -83,6 +86,13 @@ All these examples work the same with processes, live processes, and memory.
 Passenger reuses running processes in a sort of LIFO manner. This means that when it needs a process to handle a request, and there are running processes not currently busy handling requests, it will preferably take first the one that was run the most recently. This feature is quite handy to know how many processes a particular application, or all running applications, actually ever execute in parallel.
 
 In order to estimate the live process count, **check\_passenger** takes a look at those that have been run in the last 300 seconds (or 5 minutes). This works well as long as **check\_passenger** is executed with a periodicity of 5 minutes or less.
+
+
+## Passenger Request Queues
+
+Phusion Passenger's internal state consists of a list of Groups (representing applications), each which consist of a list of Processes (representing application processes). When spawning the first process for an application, Phusion Passenger has to create and initialize a Group data structure, run hooks, etc. Since this involves reading from disk and running processes, it can potentially take an arbitrary amount of time. During that time, said request, and any new requests targeted at that application, are put in the top-level queue until the Group is done initializing.
+
+Each Group has its own queue. As soon as the Group is initialized, relevant requests from the top-level queue are moved to the Group-local queue. This is the reason why the top-level queue is usually empty. The sum of the values of all Group-local queues, plus the value of the top-level queue, is the total number of requests that are queued. In general, if they are non-zero and increasing, the number of workers needs to be increased.
 
 
 ## Data Caching

--- a/bin/check_passenger
+++ b/bin/check_passenger
@@ -46,6 +46,15 @@ class CheckPassengerCLI < Thor
     end
   end
 
+  desc 'requests', 'Check queued Passenger requests'
+  option :warn, aliases: 'w', banner: 'Request count threshold to raise warning status'
+  option :crit, aliases: 'c', banner: 'Request count threshold to raise critical status'
+  def requests
+    run_check do
+      CheckPassenger::Check.request_count(options)
+    end
+  end
+
   private
 
   def dump_passenger_status_output(exception = nil)

--- a/lib/check_passenger/check.rb
+++ b/lib/check_passenger/check.rb
@@ -10,7 +10,8 @@ module CheckPassenger
       COUNTER_LABELS = {
         live_process_count: ['%d live process', '%d live processes'],
         memory: '%dMB memory used',
-        process_count: ['%d process', '%d processes']
+        process_count: ['%d process', '%d processes'],
+        request_count: ['%d request', '%d requests']
       }
 
       def check_counter(counter_name, options = {})

--- a/test/passenger-status
+++ b/test/passenger-status
@@ -9,7 +9,7 @@ Instance: 32028
 ----------- General information -----------
 Max pool size : 40
 Processes     : 26
-Requests in top-level queue : 0
+Requests in top-level queue : 10
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
@@ -42,7 +42,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 2
   * PID: 26712   Sessions: 0       Processed: 184     Uptime: 21h 36m 36s
     CPU: 0%      Memory  : 26M     Last used: 1m 11s
   * PID: 26721   Sessions: 0       Processed: 0       Uptime: 21h 36m 35s
@@ -54,7 +54,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 3
   * PID: 17507   Sessions: 0       Processed: 2141    Uptime: 21h 43m 33s
     CPU: 0%      Memory  : 242M    Last used: 5h 51m
   * PID: 17514   Sessions: 0       Processed: 5967    Uptime: 21h 43m 33s
@@ -70,7 +70,7 @@ Requests in top-level queue : 0
 
 /home/application_4/Site#default:
   App root: /home/application_4/Site
-  Requests in queue: 0
+  Requests in queue: 4
   * PID: 32383   Sessions: 0       Processed: 2182    Uptime: 2h 7m 9s
     CPU: 0%      Memory  : 76M     Last used: 2s ago
   * PID: 23605   Sessions: 0       Processed: 609     Uptime: 1h 7m 25s

--- a/test/sample_output_1.txt
+++ b/test/sample_output_1.txt
@@ -4,12 +4,12 @@ Instance: 32028
 ----------- General information -----------
 Max pool size : 40
 Processes     : 26
-Requests in top-level queue : 0
+Requests in top-level queue : 10
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 11
   * PID: 12396   Sessions: 0       Processed: 13322   Uptime: 19h 12m 52s
     CPU: 0%      Memory  : 153M    Last used: 51m 29s
   * PID: 12404   Sessions: 0       Processed: 11694   Uptime: 19h 12m 52s
@@ -37,7 +37,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 12
   * PID: 26712   Sessions: 0       Processed: 184     Uptime: 21h 36m 36s
     CPU: 0%      Memory  : 26M     Last used: 1m 11s
   * PID: 26721   Sessions: 0       Processed: 0       Uptime: 21h 36m 35s
@@ -49,7 +49,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 13
   * PID: 17507   Sessions: 0       Processed: 2141    Uptime: 21h 43m 33s
     CPU: 0%      Memory  : 242M    Last used: 5h 51m
   * PID: 17514   Sessions: 0       Processed: 5967    Uptime: 21h 43m 33s
@@ -65,7 +65,7 @@ Requests in top-level queue : 0
 
 /home/application_4/Site#default:
   App root: /home/application_4/Site
-  Requests in queue: 0
+  Requests in queue: 14
   * PID: 32383   Sessions: 0       Processed: 2182    Uptime: 2h 7m 9s
     CPU: 0%      Memory  : 76M     Last used: 2s ago
   * PID: 23605   Sessions: 0       Processed: 609     Uptime: 1h 7m 25s

--- a/test/sample_output_2.txt
+++ b/test/sample_output_2.txt
@@ -4,12 +4,12 @@ Instance: 28669
 ----------- General information -----------
 Max pool size : 40
 Processes     : 22
-Requests in top-level queue : 0
+Requests in top-level queue : 12
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 21
   * PID: 10966   Sessions: 0       Processed: 10840   Uptime: 15h 39m 16s
     CPU: 1%      Memory  : 170M    Last used: 17s ago
   * PID: 10974   Sessions: 0       Processed: 0       Uptime: 15h 39m 16s
@@ -37,7 +37,7 @@ Requests in top-level queue : 0
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 22
   * PID: 1679    Sessions: 0       Processed: 1273    Uptime: 3d 17h 40m 10s
     CPU: 0%      Memory  : 45M     Last used: 6m 4
   * PID: 1686    Sessions: 0       Processed: 0       Uptime: 3d 17h 40m 10s
@@ -49,7 +49,7 @@ Requests in top-level queue : 0
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 23
   * PID: 8170    Sessions: 0       Processed: 13179   Uptime: 1d 12h 8m 46s
     CPU: 1%      Memory  : 612M    Last used: 0s ag
   * PID: 8180    Sessions: 0       Processed: 20043   Uptime: 1d 12h 8m 45s

--- a/test/sample_output_3.txt
+++ b/test/sample_output_3.txt
@@ -4,24 +4,24 @@ Instance: 1965
 ----------- General information -----------
 Max pool size : 50
 Processes     : 6
-Requests in top-level queue : 0
+Requests in top-level queue : 13
 
 ----------- Application groups -----------
 /home/application_1/Site#default:
   App root: /home/application_1/Site
-  Requests in queue: 0
+  Requests in queue: 1
   * PID: 14518   Sessions: 0       Processed: 11723   Uptime: 20h 8m 7s
     CPU: 0%      Memory  : 144M    Last used: 1m 33s ag
 
 /home/application_2/Site#default:
   App root: /home/application_2/Site
-  Requests in queue: 0
+  Requests in queue: 32
   * PID: 14134   Sessions: 0       Processed: 2313    Uptime: 20h 8m 10s
     CPU: 0%      Memory  : 63M     Last used: 6h 22m 4
 
 /home/application_3/Site#default:
   App root: /home/application_3/Site
-  Requests in queue: 0
+  Requests in queue: 33
   * PID: 21058   Sessions: 0       Processed: 725     Uptime: 2d 22h 35m 38s
     CPU: 0%      Memory  : 30M     Last used: 5m 4
   * PID: 21071   Sessions: 0       Processed: 0       Uptime: 2d 22h 35m 38s

--- a/test/test_check.rb
+++ b/test/test_check.rb
@@ -73,6 +73,17 @@ describe CheckPassenger::Check do
         assert_equal 9, output_data.first[:value]
       end
 
+      it 'reports global request queue' do
+        options = { parsed_data: @parsed_data }
+        output_status, output_data = CheckPassenger::Check.request_count(options)
+
+        assert :ok, output_status
+        output_data_structure_test(output_data)
+
+        assert_equal 'request_count', output_data.first[:counter]
+        assert_equal 60, output_data.first[:value]
+      end
+
       it 'reports application process count' do
         options = { parsed_data: @parsed_data, app_name: 'application_1' }
         output_status, output_data = CheckPassenger::Check.process_count(options)
@@ -106,6 +117,17 @@ describe CheckPassenger::Check do
         assert_equal 1, output_data.first[:value]
       end
 
+      it 'reports application request queue count' do
+        options = { parsed_data: @parsed_data, app_name: 'application_4' }
+        output_status, output_data = CheckPassenger::Check.request_count(options)
+
+        assert_equal :ok, output_status
+        output_data_structure_test(output_data)
+
+        assert_equal 'request_count', output_data.first[:counter]
+        assert_equal 14, output_data.first[:value]
+      end
+
       it 'sets a warn alert when value over threshold' do
         options = { parsed_data: @parsed_data, app_name: 'application_4', warn: '150', crit: '300' }
         output_status, output_data = CheckPassenger::Check.memory(options)
@@ -133,24 +155,32 @@ describe CheckPassenger::Check do
       assert output_data.first[:text] =~ /\b6 processes\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b1 live process\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b30 requests\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_1' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b1 process\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b1 live process\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b1 request\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_2' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b1 process\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b0 live processes\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b32 requests\b/, output_data.first[:text]
 
       options = { parsed_data: @parsed_data, app_name: 'application_3' }
       output_status, output_data = CheckPassenger::Check.process_count(options)
       assert output_data.first[:text] =~ /\b4 processes\b/, output_data.first[:text]
       output_status, output_data = CheckPassenger::Check.live_process_count(options)
       assert output_data.first[:text] =~ /\b0 live processes\b/, output_data.first[:text]
+      output_status, output_data = CheckPassenger::Check.request_count(options)
+      assert output_data.first[:text] =~ /\b33 requests\b/, output_data.first[:text]
     end
 
     it 'raises an alert if the application is not running' do

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -92,6 +92,10 @@ describe CheckPassenger::Parser do
       it 'reports the number of live processes' do
         assert_equal 9, @parser.live_process_count
       end
+
+      it 'reports the number of requests queued' do
+        assert_equal 60, @parser.request_count
+      end
     end
 
     describe 'for a specific application' do
@@ -106,6 +110,10 @@ describe CheckPassenger::Parser do
       it 'reports the live process count' do
         assert_equal 3, @parser.live_process_count('application_1')
         assert_equal 4, @parser.live_process_count('application_4')
+      end
+
+      it 'reports the requests queued' do
+        assert_equal 12, @parser.request_count('application_2')
       end
 
       it 'raises exception if term matches multiple apps' do


### PR DESCRIPTION
I think I've fixed all the previous problems we discussed in the previous PR. I wasn't quite how to update the PR and decided a new one was simpler.

Global requests should always have a number so it seemed reasonable to inject that value and then sum the requests per applications. The behavior should be less surprising now. Thanks for the suggestion.
https://github.com/rkhatibi/check_passenger/blob/a49098608309bebd58c4d8fc8a0795ab104c43dd/lib/check_passenger/parser.rb#L48
